### PR TITLE
Fix/vet crosscompile

### DIFF
--- a/actions/check.go
+++ b/actions/check.go
@@ -41,7 +41,7 @@ func Check(context *cli.Context, useSecondLevelArgs bool) error {
 	burrow.Log(burrow.LOG_INFO, "check", "Checking code")
 
 	args := []string{}
-	args = append(args, "vet")
+	args = append(args, "vet", "./...") // ./... is a 'wildcard package'
 	userArgs, err := shellwords.Parse(burrow.Config.Args.Go.Vet)
 	if err != nil {
 		burrow.Log(burrow.LOG_ERR, "check", "Failed to read user arguments from config file: %s", err)

--- a/actions/check.go
+++ b/actions/check.go
@@ -39,7 +39,7 @@ func Check(context *cli.Context, useSecondLevelArgs bool) error {
 	burrow.Log(burrow.LOG_INFO, "check", "Checking code")
 
 	args := []string{}
-	args = append(args, "tool", "vet")
+	args = append(args, "vet")
 	userArgs, err := shellwords.Parse(burrow.Config.Args.Go.Vet)
 	if err != nil {
 		burrow.Log(burrow.LOG_ERR, "check", "Failed to read user arguments from config file: %s", err)
@@ -50,12 +50,9 @@ func Check(context *cli.Context, useSecondLevelArgs bool) error {
 	if useSecondLevelArgs {
 		args = append(args, burrow.GetSecondLevelArgs()...)
 	}
-
-	for _, file := range burrow.GetCodefiles() {
-		err = burrow.Exec("check", "go", append(args, file)...)
-		if err == nil {
-			burrow.UpdateTarget("check", outputs)
-		}
+	err = burrow.Exec("check", "go", args...)
+	if err == nil {
+		burrow.UpdateTarget("check", outputs)
 	}
 
 	return err

--- a/actions/check.go
+++ b/actions/check.go
@@ -20,6 +20,8 @@
 package burrow
 
 import (
+	"os"
+
 	"github.com/EmbeddedEnterprises/burrow/utils"
 	"github.com/mattn/go-shellwords"
 	"github.com/urfave/cli"
@@ -50,7 +52,12 @@ func Check(context *cli.Context, useSecondLevelArgs bool) error {
 	if useSecondLevelArgs {
 		args = append(args, burrow.GetSecondLevelArgs()...)
 	}
-	err = burrow.Exec("check", "go", args...)
+	wd, err := os.Getwd()
+	if err != nil {
+		burrow.Log(burrow.LOG_ERR, "check", "Failed to get working directory: %s", err)
+		return err
+	}
+	err = burrow.ExecDir("check", wd, "go", args...)
 	if err == nil {
 		burrow.UpdateTarget("check", outputs)
 	}

--- a/actions/create.go
+++ b/actions/create.go
@@ -212,10 +212,13 @@ func (p *Project) Dump() error {
 	}
 
 	if _, err = os.Stat(p.Location); os.IsNotExist(err) {
-		os.Mkdir(p.Location, 0755)
+		if err = os.MkdirAll(p.Location, 0755); err != nil {
+			burrow.Log(burrow.LOG_ERR, "project", "Failed to create project directory!")
+			return err
+		}
 	}
 
-	if err = os.Mkdir(path.Join(p.Location, "example"), 0755); err != nil {
+	if err = os.MkdirAll(path.Join(p.Location, "example"), 0755); err != nil {
 		burrow.Log(burrow.LOG_ERR, "project", "Failed to create example directory!")
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	actions "github.com/EmbeddedEnterprises/burrow/actions"
@@ -259,25 +258,13 @@ burrow - Copyright (c) 2017-2018  EmbeddedEnterprises
 		fmt.Fprintf(os.Stderr, "Failed to resolve working directory: %s\n", err)
 		os.Exit(1)
 	}
+
 	if wd != wdold {
-		fmt.Fprintf(os.Stderr, "wanted: %s, have: %s \n", wd, wdold)
-		if _, ok := os.LookupEnv("FORKED"); ok {
-			fmt.Printf("Fork failed!\n")
-			os.Exit(3)
-		}
-		fmt.Fprintf(os.Stderr, "pseudo-forking\n")
 		os.Chdir(wd)
 		defer os.Chdir(wdold)
-		cmd := exec.Command(os.Args[0], os.Args[1:]...)
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Dir = wd
-		cmd.Env = append([]string{fmt.Sprintf("PWD=%s", wd), "FORKED=1"}, os.Environ()...)
-		if err = cmd.Run(); err != nil {
-			os.Exit(2)
-		}
-		os.Exit(0)
+		pwdVal := os.Getenv("PWD")
+		os.Setenv("PWD", wd)
+		defer os.Setenv("PWD", pwdVal)
 	}
 
 	app.Run(os.Args)

--- a/main.go
+++ b/main.go
@@ -21,9 +21,7 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
 
 	actions "github.com/EmbeddedEnterprises/burrow/actions"
 	utils "github.com/EmbeddedEnterprises/burrow/utils"
@@ -246,25 +244,6 @@ burrow - Copyright (c) 2017-2018  EmbeddedEnterprises
 			Description: "This increments the version number stored in the burrow.yaml file by the patch part of the semantic version string.",
 			Action:      actions.Patch,
 		},
-	}
-
-	wdold, err := os.Getwd()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get current working directory: %s\n", err)
-		os.Exit(1)
-	}
-	wd, err := filepath.EvalSymlinks(wdold)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to resolve working directory: %s\n", err)
-		os.Exit(1)
-	}
-
-	if wd != wdold {
-		os.Chdir(wd)
-		defer os.Chdir(wdold)
-		pwdVal := os.Getenv("PWD")
-		os.Setenv("PWD", wd)
-		defer os.Setenv("PWD", pwdVal)
 	}
 
 	app.Run(os.Args)

--- a/utils/targets.go
+++ b/utils/targets.go
@@ -59,8 +59,8 @@ func IsTargetUpToDate(target string, outputs []string) bool {
 	}
 
 	usr, _ := user.Current()
-	_ = os.Mkdir(usr.HomeDir+"/.cache/burrow/", 0755)
-	_ = os.Mkdir(usr.HomeDir+"/.cache/burrow/"+projectHash, 0755)
+	_ = os.MkdirAll(usr.HomeDir+"/.cache/burrow/", 0755)
+	_ = os.MkdirAll(usr.HomeDir+"/.cache/burrow/"+projectHash, 0755)
 
 	cache, err := ioutil.ReadFile(usr.HomeDir + "/.cache/burrow/" + projectHash + "/" + target)
 	if err != nil {


### PR DESCRIPTION
Use `go vet` instead of go tool vet. 

To have this work, I added a piece of code which performs an `os.Chdir` on the burrow process to be executed within the `GOPATH`.

This fixes import errors when checking code while cross-compiling.